### PR TITLE
Justin/fix homepage navbar

### DIFF
--- a/components/aboutus/AdvisorCard.tsx
+++ b/components/aboutus/AdvisorCard.tsx
@@ -10,7 +10,7 @@ const AdvisorCard = ({ data }: AdvisorCardProps) => {
     <div className="flex flex-row justify-center gap-x-5 sm:gap-x-16">
       {data.map((item: any, index: number) => (
         <div className="flex flex-col gap-y-3" key={index}>
-          <div className="relative h-[119px] w-[119px] sm:h-[228px] sm:w-[228px] md:h-[337px] md:w-[337px]">
+          <div className="relative size-[119px] sm:size-[228px] md:size-[337px]">
             <Image
               src={item.imgSrc}
               alt="Insert Photo Here"

--- a/components/aboutus/ExcoCard.tsx
+++ b/components/aboutus/ExcoCard.tsx
@@ -11,10 +11,10 @@ const ExcoCard = ({ data }: ExcoCardProps) => {
     <div className="flex flex-row justify-center gap-x-5 overflow-x-auto py-4 sm:gap-x-16">
       {data.map((item: any, index: number) => (
         <div
-          className="flex h-[150px] w-[150px] flex-col items-center justify-center rounded-[13.18px] leading-tight shadow-[0_2px_20px_3px_rgba(0,0,0,0.1)] sm:h-[350px] sm:w-[350px] sm:rounded-[20px]"
+          className="flex size-[150px] flex-col items-center justify-center rounded-[13.18px] leading-tight shadow-[0_2px_20px_3px_rgba(0,0,0,0.1)] sm:size-[350px] sm:rounded-[20px]"
           key={index}
         >
-          <div className="relative mt-3 flex h-[80px] w-[80px] transition-transform duration-1000 ease-in-out hover:scale-110 sm:mt-8 sm:h-[150px] sm:w-[150px]">
+          <div className="relative mt-3 flex size-[80px] transition-transform duration-1000 ease-in-out hover:scale-110 sm:mt-8 sm:size-[150px]">
             <Image
               src={item.imgSrc}
               alt="Insert Photo Here"

--- a/components/aboutus/LinkedInLogo.tsx
+++ b/components/aboutus/LinkedInLogo.tsx
@@ -8,7 +8,7 @@ const LinkedInLogo = ({ link }: LinkedInLogoProps) => {
   return (
     <a href={link} title="Linkedin Page">
       <svg
-        className="h-[6px] w-[6px] fill-current text-black sm:h-[1.25rem] sm:w-[1.25rem]"
+        className="size-[6px] fill-current text-black sm:size-[1.25rem]"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 16 16"
       >

--- a/components/contact/ContactInfoCard.tsx
+++ b/components/contact/ContactInfoCard.tsx
@@ -9,7 +9,7 @@ import SocialHandles from './SocialHandles';
 const ContactInfoCard = () => {
   return (
     <div className="relative h-[330px] bg-[#002750]/80 px-10 py-12 text-white sm:h-[520px] sm:px-12 sm:py-16 lg:h-[580px] lg:rounded-r-[20px] 2xl:h-[540px] 2xl:px-16">
-      <div className="absolute -z-10 -mx-10 -my-12 h-full w-full sm:-mx-12 sm:-my-16 2xl:-m-16">
+      <div className="absolute -z-10 -mx-10 -my-12 size-full sm:-mx-12 sm:-my-16 2xl:-m-16">
         <Image
           src="/images/contact/contact_info_image.jpg"
           alt="Contact Info Logo"

--- a/components/contact/SocialHandles.tsx
+++ b/components/contact/SocialHandles.tsx
@@ -12,7 +12,7 @@ const SocialHandles = () => {
         title="NUS FinTech Society LinkedIn Page"
       >
         <svg
-          className="h-5 w-5 fill-current text-white sm:h-8 sm:w-8"
+          className="size-5 fill-current text-white sm:size-8"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
         >
@@ -25,7 +25,7 @@ const SocialHandles = () => {
         title="NUS FinTech Society Instagram Page"
       >
         <svg
-          className="h-5 w-5 fill-current text-white sm:h-8 sm:w-8"
+          className="size-5 fill-current text-white sm:size-8"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
         >
@@ -38,7 +38,7 @@ const SocialHandles = () => {
         title="NUS FinTech Society Facebook Page"
       >
         <svg
-          className="h-5 w-5 fill-current text-white sm:h-8 sm:w-8"
+          className="size-5 fill-current text-white sm:size-8"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 16 16"
         >
@@ -51,7 +51,7 @@ const SocialHandles = () => {
         title="NUS FinTech Society Twitter Page"
       >
         <svg
-          className="h-5 w-5 fill-current text-white sm:h-8 sm:w-8"
+          className="size-5 fill-current text-white sm:size-8"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="328 355 335 276"
         >
@@ -79,7 +79,7 @@ const SocialHandles = () => {
         title="NUS FinTech Society Blockchain Medium Page"
       >
         <svg
-          className="h-5 w-5 fill-current text-white sm:h-8 sm:w-8"
+          className="size-5 fill-current text-white sm:size-8"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 256 256"
         >
@@ -91,7 +91,7 @@ const SocialHandles = () => {
         title="NUS FinTech Society Machine Learning Medium Page"
       >
         <svg
-          className="h-5 w-5 fill-current text-white sm:h-8 sm:w-8"
+          className="size-5 fill-current text-white sm:size-8"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 32 32"
         >

--- a/components/contact/accordion.tsx
+++ b/components/contact/accordion.tsx
@@ -35,7 +35,7 @@ const Accordion = ({ questions }: AccordionProps) => {
           </h3>
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className={`h-3 w-3 transition-transform ${
+            className={`size-3 transition-transform ${
               expandedIndex === index ? 'rotate-180' : ''
             }`}
             viewBox="0 0 24 24"

--- a/components/contact/landing.tsx
+++ b/components/contact/landing.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 const Landing = () => {
   return (
     <div className="relative h-[calc(50vh-64px)] min-h-[400px] w-screen">
-      <div className="absolute -z-10 h-full w-full overflow-hidden">
+      <div className="absolute -z-10 size-full overflow-hidden">
         <Image
           src="/images/contact/contact_landing_min.jpg"
           alt="Insert Photo Here"
@@ -14,8 +14,8 @@ const Landing = () => {
         />
       </div>
       <MaxWidth>
-        <div className=" pt-[20vh] text-center">
-          <div className="text-5xl  font-bold text-[#FFFF] sm:text-6xl lg:text-7xl">
+        <div className="pt-[20vh] text-center">
+          <div className="text-5xl font-bold text-[#FFFF] sm:text-6xl lg:text-7xl">
             Contact Us
           </div>
         </div>

--- a/components/departments/DepartmentInfo.tsx
+++ b/components/departments/DepartmentInfo.tsx
@@ -22,8 +22,8 @@ const DepartmentInfo = ({
         <h1 className="ml-4 mt-3 border-b-2 border-[#002750] sm:ml-6 sm:mt-10 sm:border-b-4 sm:text-6xl sm:leading-[4.538rem]">{`${name}`}</h1>
       </div>
 
-      <div className="grid grid-cols-1 mt-10 flex-row sm:gap-x-20 md:grid-cols-2 gap-4">
-        <div className="relative flex flex-col h-full flex-1 rounded-xl bg-[#090071]/70 px-8 text-white sm:rounded-[20px] sm:px-12 py-8 sm:py-12 gap-8">
+      <div className="mt-10 grid grid-cols-1 flex-row gap-4 sm:gap-x-20 md:grid-cols-2">
+        <div className="relative flex h-full flex-1 flex-col gap-8 rounded-xl bg-[#090071]/70 p-8 text-white sm:rounded-[20px] sm:p-12">
           <Image
             src="/images/section-header.jpg"
             alt=""

--- a/components/departments/FeaturedProjects.tsx
+++ b/components/departments/FeaturedProjects.tsx
@@ -70,7 +70,7 @@ const FeaturedProjects = ({ projects }: FeaturedProjectsProps) => {
         <MenuButton
           as={Button}
           rightIcon={<ChevronDownIcon />}
-          className="rounded-[13px] bg-teal-700 text-white p-2 ml-8 mt-4"
+          className="ml-8 mt-4 rounded-[13px] bg-teal-700 p-2 text-white"
         >
           {category}
         </MenuButton>

--- a/components/departments/carousel.tsx
+++ b/components/departments/carousel.tsx
@@ -65,7 +65,7 @@ const DeptCarousel = ({
           <p className="text-left sm:mb-9 sm:mt-10 sm:text-lg">{vision}</p>
         </div>
         <div className="p-8 text-white sm:px-14 sm:py-10">
-          <h2 className="flex text-xl font-bold sm:mb-6 sm:text-3xl overflow-auto">
+          <h2 className="flex overflow-auto text-xl font-bold sm:mb-6 sm:text-3xl">
             Co-Directors
           </h2>
           {directors.map((director) => {
@@ -73,7 +73,7 @@ const DeptCarousel = ({
               // Add more margins if there is only 1 director
               <Fragment key={director.src}>
                 <div className="mb-28 mt-3 flex sm:mb-36 sm:mt-5">
-                  <div className="relative mr-6 h-[75px] w-[75px] sm:h-[105px] sm:w-[105px]">
+                  <div className="relative mr-6 size-[75px] sm:size-[105px]">
                     <Image
                       src={director.src}
                       alt={director.alt}
@@ -88,7 +88,7 @@ const DeptCarousel = ({
                   <div className="ml-10 mt-7 sm:mt-10">
                     <a href={director.linkedin} title="Director Linkedin Page">
                       <svg
-                        className="h-5 w-5 fill-current text-white sm:h-6 sm:w-6"
+                        className="size-5 fill-current text-white sm:size-6"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 16 16"
                       >
@@ -101,7 +101,7 @@ const DeptCarousel = ({
             ) : (
               <Fragment key={director.src}>
                 <div className="mb-5 mt-6 flex sm:mt-5">
-                  <div className="relative mr-6 h-[75px] w-[75px] sm:h-[105px] sm:w-[105px]">
+                  <div className="relative mr-6 size-[75px] sm:size-[105px]">
                     <Image
                       src={director.src}
                       alt={director.alt}
@@ -118,7 +118,7 @@ const DeptCarousel = ({
                   <div className="ml-auto mr-16 mt-7 sm:ml-auto sm:mr-16 sm:mt-10 md:ml-auto md:mr-36 md:mt-10 lg:ml-auto lg:mr-2 lg:mt-10 xl:ml-auto xl:mr-2 xl:mt-10">
                     <a href={director.linkedin} title="Director Linkedin Page">
                       <svg
-                        className="h-5 w-5 fill-current text-white sm:h-6 sm:w-6"
+                        className="size-5 fill-current text-white sm:size-6"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 16 16"
                       >

--- a/components/events/Landing.tsx
+++ b/components/events/Landing.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 const Landing = () => {
   return (
     <div className="relative h-[calc(50vh-64px)] min-h-[400px] w-screen">
-      <div className="absolute -z-10 h-full w-full overflow-hidden">
+      <div className="absolute -z-10 size-full overflow-hidden">
         <Image
           src="/images/events/eventsHeader.jpg"
           alt="Insert Photo Here"

--- a/components/exco/index.tsx
+++ b/components/exco/index.tsx
@@ -19,7 +19,7 @@ const Exco = ({ categories }: ExcoProps) => {
                     className="basis-[280px] rounded-lg border border-gray-400 p-2 sm:basis-[400px]"
                   >
                     <div className="flex">
-                      <div className="relative h-[116px] w-[116px] sm:h-[160px] sm:w-[160px] ">
+                      <div className="relative size-[116px] sm:size-[160px] ">
                         <Image
                           src={imgSrc}
                           alt="picture"

--- a/components/exco/topBanner.tsx
+++ b/components/exco/topBanner.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 const TopBanner = () => {
   return (
     <div className="relative h-[calc(50vh-64px)] min-h-[400px] w-screen">
-      <div className="absolute -z-10 h-full w-full overflow-hidden">
+      <div className="absolute -z-10 size-full overflow-hidden">
         <Image
           src="/images/exco/banner.jpg"
           alt="Insert Photo Here"

--- a/components/home/HomeNavbar.tsx
+++ b/components/home/HomeNavbar.tsx
@@ -32,7 +32,7 @@ const HomeNavbar = () => {
     <nav className="relative z-10 w-[100vw]">
       <div className="flex text-white">
         <div className="relative ml-4 mt-3 flex h-[50px] w-[100px] cursor-pointer font-bold sm:ml-20 sm:h-[77px] sm:w-[144px]">
-          <Link href="/">
+          <Link href="/" passHref>
             <Image
               src="/images/fintechsoc-logo.png"
               alt="NUS FinTech Society Logo"
@@ -87,7 +87,7 @@ const HomeNavbar = () => {
                         <Link href={item[1]}>
                           <a
                             onClick={handleCloseNav}
-                            className=" h-full w-full p-2"
+                            className=" size-full p-2"
                           >
                             {item[0]}
                           </a>
@@ -126,7 +126,7 @@ const HomeNavbar = () => {
                         <Link href={item[1]}>
                           <a
                             onClick={handleCloseNav}
-                            className=" h-full w-full p-2"
+                            className=" size-full p-2"
                           >
                             {item[0]}
                           </a>

--- a/components/home/Landing.tsx
+++ b/components/home/Landing.tsx
@@ -6,7 +6,7 @@ const Landing = () => {
   return (
     <div className="relative -mb-10 min-h-[400px] w-screen sm:h-[calc(80vh)]">
       <div className="absolute top-[-90px] h-[50%] w-full bg-gradient-to-b from-[#002750B3] via-[#00275059] to-[#00275000]" />
-      <div className="absolute top-[-90px] -z-10 h-full w-full overflow-hidden bg-primary">
+      <div className="absolute top-[-90px] -z-10 size-full overflow-hidden bg-primary">
         <Image
           src="/images/home/home_img.jpg"
           alt="Insert Photo Here"
@@ -18,7 +18,7 @@ const Landing = () => {
       </div>
 
       <MaxWidth>
-        <div className="relative flex cursor-default flex-col gap-y-3 text-center sm:pt-[max(20px,_5vh)]">
+        <div className="relative flex cursor-default flex-col gap-y-3 pt-[max(20px,_5vh)] text-center">
           <h1 className="text-2xl font-bold text-white sm:text-6xl">
             NUS Fintech Society
           </h1>

--- a/components/home/Milestones.tsx
+++ b/components/home/Milestones.tsx
@@ -11,7 +11,7 @@ const Milestones = () => {
     <div className="section-my">
       <h2 className="mb-20 text-center text-h2 font-bold">Key Milestones</h2>
       <div className="flex flex-wrap justify-center gap-10">
-        <div className=" flex h-72 w-72 flex-col items-center justify-center bg-primary text-white">
+        <div className=" flex size-72 flex-col items-center justify-center bg-primary text-white">
           <div className="text-5xl">
             <CountUp
               start={memberCount ? 100 : undefined}
@@ -34,7 +34,7 @@ const Milestones = () => {
           </div>
           <div className=" mt-5 text-2xl capitalize">MEMBERS</div>
         </div>
-        <div className=" flex h-72 w-72 flex-col items-center justify-center bg-primary text-white">
+        <div className=" flex size-72 flex-col items-center justify-center bg-primary text-white">
           <div className="text-5xl">
             <CountUp
               start={projectsCount ? 0 : undefined}
@@ -59,7 +59,7 @@ const Milestones = () => {
             COMPLETED <div> PROJECTS</div>
           </div>
         </div>
-        <div className=" flex h-72 w-72 flex-col items-center justify-center bg-primary text-white">
+        <div className=" flex size-72 flex-col items-center justify-center bg-primary text-white">
           <div className="text-5xl">
             <CountUp
               start={deptCount ? 0 : undefined}

--- a/components/home/Partners.tsx
+++ b/components/home/Partners.tsx
@@ -8,7 +8,7 @@ import SectionHeader from '@components/layout/SectionHeader';
 
 const Partners = ({ partnersImages }: PartnersProps) => {
   return (
-    <div className="sm:section-my mt-10">
+    <div className="sm:section-my my-10">
       <SectionHeader
         color="green"
         title="Our Partners"
@@ -19,7 +19,7 @@ const Partners = ({ partnersImages }: PartnersProps) => {
         {partnersImages.map(({ src, alt, url }, index) => {
           return (
             <Fragment key={index}>
-              <div className="relative h-20 w-20 rounded-lg hover:drop-shadow-xl sm:h-[100px] sm:w-[100px]">
+              <div className="relative size-20 rounded-lg hover:drop-shadow-xl sm:size-[100px]">
                 <a
                   href={url}
                   target="_blank"

--- a/components/layout/DropDown.tsx
+++ b/components/layout/DropDown.tsx
@@ -41,7 +41,7 @@ const DropDown = ({ items, title, handleCloseNav }: DropDownProps) => {
               <Fragment key={index}>
                 <MenuItem _hover={{ bg: 'blue.100' }} padding={0}>
                   <Link href={item[1]}>
-                    <a onClick={handleCloseNav} className=" h-full w-full p-2">
+                    <a onClick={handleCloseNav} className="size-full p-2">
                       {item[0]}
                     </a>
                   </Link>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -7,8 +7,8 @@ import MaxWidth from '@components/layout/MaxWidth';
 const Footer = () => {
   return (
     // [calc(60vh-64px)]
-    <footer className="relative bottom-0 h-[175px] w-screen items-end sm:h-[160px]">
-      <div className="absolute -z-10 h-full w-full overflow-hidden bg-gray-50">
+    <footer className="relative bottom-0 mt-5 h-[175px] w-screen items-end sm:h-[160px]">
+      <div className="absolute -z-10 size-full overflow-hidden bg-gray-50">
         <Image
           src="/images/home/footer.jpg"
           alt="Insert Photo Here"
@@ -40,7 +40,7 @@ const Footer = () => {
                 title="NUS FinTech Society LinkedIn Page"
               >
                 <svg
-                  className="h-5 w-5 fill-current text-white sm:h-6 sm:w-6"
+                  className="size-5 fill-current text-white sm:size-6"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 16 16"
                 >
@@ -53,7 +53,7 @@ const Footer = () => {
                 title="NUS FinTech Society Instagram Page"
               >
                 <svg
-                  className="h-5 w-5 fill-current text-white sm:h-6 sm:w-6"
+                  className="size-5 fill-current text-white sm:size-6"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 16 16"
                 >
@@ -66,7 +66,7 @@ const Footer = () => {
                 title="NUS FinTech Society Facebook Page"
               >
                 <svg
-                  className="h-5 w-5 fill-current text-white sm:h-6 sm:w-6"
+                  className="size-5 fill-current text-white sm:size-6"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 16 16"
                 >
@@ -79,7 +79,7 @@ const Footer = () => {
                 title="NUS FinTech Society Twitter Page"
               >
                 <svg
-                  className="h-5 w-5 fill-current text-white sm:h-6 sm:w-6"
+                  className="size-5 fill-current text-white sm:size-6"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="328 355 335 276"
                 >
@@ -107,7 +107,7 @@ const Footer = () => {
                 title="NUS FinTech Society Blockchain Medium Page"
               >
                 <svg
-                  className="h-5 w-5 fill-current text-white sm:h-6 sm:w-6"
+                  className="size-5 fill-current text-white sm:size-6"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 256 256"
                 >
@@ -119,7 +119,7 @@ const Footer = () => {
                 title="NUS FinTech Society Machine Learning Medium Page"
               >
                 <svg
-                  className="h-5 w-5 fill-current text-white sm:h-6 sm:w-6"
+                  className="size-5 fill-current text-white sm:size-6"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 32 32"
                 >
@@ -131,7 +131,7 @@ const Footer = () => {
                 title="NUS Fintech Society Youtube Page"
               >
                 <svg
-                  className="h-5 w-5 fill-current text-white sm:h-6 sm:w-6"
+                  className="size-5 fill-current text-white sm:size-6"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 576 512"
                 >

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -7,7 +7,7 @@ import MaxWidth from '@components/layout/MaxWidth';
 const Footer = () => {
   return (
     // [calc(60vh-64px)]
-    <footer className="relative bottom-0 mt-5 h-[175px] w-screen items-end sm:h-[160px]">
+    <footer className="relative bottom-0 h-[175px] w-screen items-end sm:h-[160px]">
       <div className="absolute -z-10 size-full overflow-hidden bg-gray-50">
         <Image
           src="/images/home/footer.jpg"

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -29,7 +29,7 @@ const Navbar = () => {
     <nav className="relative z-10 w-[100vw] text-sm">
       <div className="flex h-[105px] bg-white text-black">
         <div className="relative ml-10 flex w-[100px] cursor-pointer items-center font-bold">
-          <Link href="/">
+          <Link href="/" passHref>
             <div className="relative">
               <Image
                 // className="relative z-10 rounded-full"
@@ -63,30 +63,28 @@ const Navbar = () => {
                           lg:pl-0`}
           >
             <div
-              className={`flex flex-wrap lg:divide-x ${
-                isOpen ? 'rounded-xl' : 'rounded-full py-3'
-              } bg-[#DDEEFE] text-[#002750]`}
+              className={`flex rounded-xl bg-[#DDEEFE] py-3 text-[#002750] lg:divide-x lg:rounded-full`}
             >
               <li
-                className={` my-3 hover:text-gray-400 md:my-0 ${
+                className={`my-3 hover:text-gray-400 md:my-0 ${
                   isOpen ? 'px-4' : 'px-7'
                 } py-1`}
               >
-                <Link href="/" className="rounded-md px-3 py-1 text-black ">
+                <Link href="/" className="rounded-md px-3 py-1 text-black">
                   <a onClick={handleCloseNav}>HOME</a>
                 </Link>
               </li>
 
-              <li className="my-3 px-4 py-1 hover:text-gray-400 md:my-0">
+              <li className="my-3 px-3 py-1 hover:text-gray-400 md:my-0">
                 <Link
                   href="/about"
                   className="rounded-md px-3 py-1 text-white "
                 >
-                  <a onClick={handleCloseNav}>ABOUT US</a>
+                  <a onClick={handleCloseNav}>ABOUT</a>
                 </Link>
               </li>
 
-              <li className="my-3  ml-4 md:my-0 md:px-4 md:py-1 lg:ml-5 lg:py-1">
+              <li className="my-3 ml-4 md:my-0 md:px-3 md:py-1 lg:ml-5 lg:py-1">
                 <div className="lg:hidden hover:lg:visible">
                   <div className="rounded-md">DEPARTMENTS</div>
                   <ul>
@@ -116,7 +114,7 @@ const Navbar = () => {
                 </div>
               </li>
 
-              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-4 md:py-1 ">
+              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-3 md:py-1 ">
                 <Link
                   href="/events"
                   className="rounded-md px-3 py-1 text-black"
@@ -125,7 +123,7 @@ const Navbar = () => {
                 </Link>
               </li>
 
-              <li className="my-3  ml-4 md:my-0 md:px-4 md:py-1 lg:ml-5 lg:py-1">
+              <li className="my-3 ml-4 md:my-0 md:px-3 md:py-1 lg:ml-5 lg:py-1">
                 <div className="lg:hidden">
                   <div className="rounded-md ">RECRUITMENT</div>
                   <ul>
@@ -155,7 +153,7 @@ const Navbar = () => {
                 </div>
               </li>
 
-              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-4 md:py-1 ">
+              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-3 md:py-1 ">
                 <Link
                   href="/sponsors"
                   className="rounded-md px-3 py-1 text-black"
@@ -164,18 +162,18 @@ const Navbar = () => {
                 </Link>
               </li>
 
-              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-4 md:py-1">
+              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-3 md:py-1">
                 <Link href="/blogs" className="rounded-md px-3 py-1 text-black">
-                  <a onClick={handleCloseNav}>BLOGS</a>
+                  <a onClick={handleCloseNav}>BLOG</a>
                 </Link>
               </li>
 
-              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-4 md:py-1 lg:mr-5">
+              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-3 md:py-1 lg:mr-5">
                 <Link
                   href="/contact-us"
                   className="rounded-md px-3 py-1 text-black"
                 >
-                  <a onClick={handleCloseNav}>CONTACT US</a>
+                  <a onClick={handleCloseNav}>CONTACT</a>
                 </Link>
               </li>
             </div>

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -47,7 +47,7 @@ const Navbar = () => {
         <div className="mr-24 mt-6 h-[55px] lg:ml-auto">
           <div
             onClick={() => setIsOpen(!isOpen)}
-            className="absolute right-[24px] top-[37px] z-30 mt-3 -translate-y-1/2 cursor-pointer sm:right-[48px] lg:hidden"
+            className="absolute right-[24px] top-[24px] z-30 mt-3 -translate-y-1/2 cursor-pointer lg:hidden"
           >
             {isOpen ? (
               <CloseIcon width={10} height={6} />
@@ -58,24 +58,22 @@ const Navbar = () => {
 
           <ul
             className={`fixed z-20 transition-all duration-150 ease-in lg:pt-0
-                      ${isOpen ? 'top-0' : 'top-[-900px] '}
+                      ${isOpen ? 'top-0' : 'top-[-900px]'}
                           lg:static lg:z-auto lg:mt-0 lg:flex lg:w-auto lg:pb-0 
                           lg:pl-0`}
           >
             <div
-              className={`flex rounded-xl bg-[#DDEEFE] py-3 text-[#002750] lg:divide-x lg:rounded-full`}
+              className='flex rounded-xl bg-[#DDEEFE] px-2 py-3 text-[#002750] max-lg:flex-wrap max-lg:pr-12 lg:divide-x lg:rounded-full'
             >
               <li
-                className={`my-3 hover:text-gray-400 md:my-0 ${
-                  isOpen ? 'px-4' : 'px-7'
-                } py-1`}
+                className='mx-2 my-3 px-3 py-1 hover:text-gray-400 lg:my-0'
               >
                 <Link href="/" className="rounded-md px-3 py-1 text-black">
                   <a onClick={handleCloseNav}>HOME</a>
                 </Link>
               </li>
 
-              <li className="my-3 px-3 py-1 hover:text-gray-400 md:my-0">
+              <li className="mx-2 my-3 px-3 py-1 hover:text-gray-400 lg:my-0">
                 <Link
                   href="/about"
                   className="rounded-md px-3 py-1 text-white "
@@ -84,8 +82,8 @@ const Navbar = () => {
                 </Link>
               </li>
 
-              <li className="my-3 ml-4 md:my-0 md:px-3 md:py-1 lg:ml-5 lg:py-1">
-                <div className="lg:hidden hover:lg:visible">
+              <li className="mx-2 my-3 px-3 py-1 hover:text-gray-400 lg:my-0">
+                {/* <div className="lg:hidden hover:lg:visible">
                   <div className="rounded-md">DEPARTMENTS</div>
                   <ul>
                     {DEPARTMENTS_ITEMS.map((item) => (
@@ -94,27 +92,24 @@ const Navbar = () => {
                         className="my-4 ml-3 hover:text-gray-400"
                       >
                         <Link href={item[1]}>
-                          <a
-                            onClick={handleCloseNav}
-                            className=" h-full w-full p-2"
-                          >
+                          <a onClick={handleCloseNav} className="size-full p-2">
                             {item[0]}
                           </a>
                         </Link>
                       </li>
                     ))}
                   </ul>
-                </div>
-                <div className="hidden lg:block">
-                  <DropDown
-                    handleCloseNav={handleCloseNav}
-                    title="DEPARTMENTS"
-                    items={DEPARTMENTS_ITEMS}
-                  />
-                </div>
+                </div> */}
+                {/* <div className="lg:block"> */}
+                <DropDown
+                  handleCloseNav={handleCloseNav}
+                  title="DEPARTMENTS"
+                  items={DEPARTMENTS_ITEMS}
+                />
+                {/* </div> */}
               </li>
 
-              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-3 md:py-1 ">
+              <li className="mx-2 my-3 px-3 py-1 hover:text-gray-400 lg:my-0">
                 <Link
                   href="/events"
                   className="rounded-md px-3 py-1 text-black"
@@ -123,8 +118,8 @@ const Navbar = () => {
                 </Link>
               </li>
 
-              <li className="my-3 ml-4 md:my-0 md:px-3 md:py-1 lg:ml-5 lg:py-1">
-                <div className="lg:hidden">
+              <li className="mx-2 my-3 px-3 py-1 hover:text-gray-400 lg:my-0">
+                {/* <div className="lg:hidden">
                   <div className="rounded-md ">RECRUITMENT</div>
                   <ul>
                     {RECRUITMENT_ITEMS.map((item) => (
@@ -133,27 +128,24 @@ const Navbar = () => {
                         className="my-4 ml-3 hover:text-gray-400"
                       >
                         <Link href={item[1]}>
-                          <a
-                            onClick={handleCloseNav}
-                            className=" h-full w-full p-2"
-                          >
+                          <a onClick={handleCloseNav} className="size-full p-2">
                             {item[0]}
                           </a>
                         </Link>
                       </li>
                     ))}
                   </ul>
-                </div>
-                <div className=" hidden lg:block">
+                </div> */}
+                {/* <div className="hidden lg:block"> */}
                   <DropDown
                     handleCloseNav={handleCloseNav}
                     title="RECRUITMENT"
                     items={RECRUITMENT_ITEMS}
                   />
-                </div>
+                {/* </div> */}
               </li>
 
-              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-3 md:py-1 ">
+              <li className="mx-2 my-3 px-3 py-1 hover:text-gray-400 lg:my-0">
                 <Link
                   href="/sponsors"
                   className="rounded-md px-3 py-1 text-black"
@@ -162,13 +154,13 @@ const Navbar = () => {
                 </Link>
               </li>
 
-              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-3 md:py-1">
+              <li className="mx-2 my-3 px-3 py-1 hover:text-gray-400 lg:my-0">
                 <Link href="/blogs" className="rounded-md px-3 py-1 text-black">
                   <a onClick={handleCloseNav}>BLOG</a>
                 </Link>
               </li>
 
-              <li className="my-3 ml-4 hover:text-gray-400 md:my-0 md:px-3 md:py-1 lg:mr-5">
+              <li className="mx-2 my-3 px-3 py-1 hover:text-gray-400 lg:my-0">
                 <Link
                   href="/contact-us"
                   className="rounded-md px-3 py-1 text-black"

--- a/components/recruitment/Landing.tsx
+++ b/components/recruitment/Landing.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 const Landing = () => {
   return (
     <div className="relative h-[calc(50vh-64px)] min-h-[400px] w-screen">
-      <div className="absolute -z-10 h-full w-full overflow-hidden">
+      <div className="absolute -z-10 size-full overflow-hidden">
         <Image
           src="/images/soc-bg.jpg"
           alt="Insert Photo Here"

--- a/components/recruitment/RoleCard.tsx
+++ b/components/recruitment/RoleCard.tsx
@@ -23,13 +23,13 @@ const RoleCard: React.FC<RoleCardProps> = ({ title, img }) => {
         </h1>
       </div>
       <div className="absolute right-[-45px] top-[-10px] z-[-5]">
-        <div className={`bg-[${iconColor}] flex h-48 w-48 items-center justify-center rounded-full`}>
+        <div className={`bg-[${iconColor}] flex size-48 items-center justify-center rounded-full`}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
               stroke={iconColor}
-              className="h-10 w-10"
+              className="size-10"
             >
               {/* Place your SVG icon here */}
             </svg>

--- a/components/recruitment/index.tsx
+++ b/components/recruitment/index.tsx
@@ -221,7 +221,7 @@ const Recruitment = () => {
                 index={selectedTab === 1 ? 0 : 1}
               >
                 <TabList>
-                  <Link href="/recruitment/technical-wing">
+                  <Link href="/recruitment/technical-wing" passHref>
                     <Tab
                       className="flex-1"
                       _selected={{
@@ -233,7 +233,7 @@ const Recruitment = () => {
                       Technical Wing
                     </Tab>
                   </Link>
-                  <Link href="/recruitment/operations-wing">
+                  <Link href="/recruitment/operations-wing" passHref>
                     <Tab
                       className="flex-1"
                       _selected={{

--- a/components/roles/SubteamsCard.tsx
+++ b/components/roles/SubteamsCard.tsx
@@ -9,7 +9,7 @@ const SubteamsCard = ({
   return (
     <div>
       <div className="mx-auto flex h-[300px] w-[260px] flex-col justify-center space-y-5 rounded-[10px] bg-[#EEF6FE] px-10 shadow-[0_2px_10px_3px_rgba(0,0,0,0.06)] md:min-h-[500px] md:min-w-[400px] md:rounded-[20px] lg:min-h-[560px] lg:min-w-[450px]">
-        <div className="relative h-[100px] w-[100px] self-center md:mb-2 md:min-h-[256px] md:min-w-[256px]">
+        <div className="relative size-[100px] self-center md:mb-2 md:min-h-[256px] md:min-w-[256px]">
           <Image
             src={teamImage.src}
             alt={teamImage.alt}

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -50,7 +50,7 @@ const AboutPage = () => {
         <div className="grid gap-x-8 rounded-b-[143px] lg:grid-cols-2">
           <div className="flex justify-center pb-4">
             {/* landing bg */}
-            <div className="h-[300px] w-[300px] sm:h-[400px] sm:w-[400px]">
+            <div className="size-[300px] sm:size-[400px]">
               <Image
                 src="/images/soc-bg.jpg"
                 alt="Insert Photo Here"

--- a/pages/blogs/index.tsx
+++ b/pages/blogs/index.tsx
@@ -40,9 +40,9 @@ function BlogCard({
   };
 }) {
   return (
-    <Link href={`/blogs/${id}`} key={id}>
+    <Link href={`/blogs/${id}`} key={id} passHref>
       <div className="flex h-96 w-[90%] gap-4 rounded-lg bg-slate-100 p-6 drop-shadow-lg hover:cursor-pointer lg:w-[40%]">
-        <div className="flex h-full w-full flex-col justify-between gap-4">
+        <div className="flex size-full flex-col justify-between gap-4">
           <h1 className="text-xl font-bold lg:text-2xl">{title}</h1>
           <h2 className="text-lg font-semibold  lg:text-xl">{date}</h2>
         </div>

--- a/styles/sponsors/styles.tsx
+++ b/styles/sponsors/styles.tsx
@@ -7,7 +7,6 @@ export const SponsorWrapper = chakra(Box, {
     backgroundColor: '#20345b',
     paddingTop: '34px',
     paddingX: '34px',
-    height: '100vh',
   },
 });
 

--- a/styles/sponsors/styles.tsx
+++ b/styles/sponsors/styles.tsx
@@ -26,6 +26,7 @@ export const HeaderContainer = chakra(Box, {
     justifyContent: 'center',
     paddingBottom: '70px',
     color: 'white',
+    lineHeight: '1.2',
   },
   sizes: {
     lg: {


### PR DESCRIPTION
# Changes
- Fixed navbar wrap-around when screen width lg-xl (WEBSITE-42)
- Converted mobile navbar to dropdowns similar to desktop (WEBSITE-43)
- Fixed sponsors being cut off on Sponsors page (WEBSITE-45)
- Fixed landing text "NUS Fintech Society" missing top padding on mobile
- Added bottom margin to partners on home page for clarity
- Increased line-height for title text on Sponsors page on mobile
## Miscellaneous
- Fixed TailwindCSS warnings (class order, size-full, etc.)